### PR TITLE
Change params to json in post request

### DIFF
--- a/figshare.py
+++ b/figshare.py
@@ -161,7 +161,7 @@ class FigShare:
             return self.__cache[hash_key]
         else:
             headers = { "Authorization": "token " + self.token } if self.token else {}
-            result = post(self.base_url + url, headers=headers, params=params).json()
+            result = post(self.base_url + url, headers=headers, json=params).json()
             self.__cache[hash_key] = result
             self.save_cache()
             return result


### PR DESCRIPTION
This pull request makes a small but important change to the way POST requests are made in the `figshare.py` file. The `params` argument is now sent as JSON in the request body instead of as URL parameters.

- Changed the `__post` method to send the `params` argument as JSON in the POST request body by using the `json` parameter instead of `params` in the `post` function.