### PR TITLE
Enable scheduled workflow for weekly runs

### DIFF
--- a/.github/workflows/uoa11-figshare-processing.yaml
+++ b/.github/workflows/uoa11-figshare-processing.yaml
@@ -11,11 +11,11 @@ on:
         options:
           - 'true'
           - 'false'
-  # schedule:
-  #   - cron: "30 */12 * * *"
-  # push:
-  #   branches:
-  #     - main
+  schedule:
+    - cron: "30 */12 * * 0"
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow trigger schedule in `.github/workflows/uoa11-figshare-processing.yaml`. The schedule and push triggers, which were previously commented out, are now enabled with a modified cron schedule.

Workflow trigger updates:

* Enabled the `schedule` trigger with a new cron expression to run the workflow every 12 hours on Sundays instead of every 12 hours daily.
* Enabled the `push` trigger for the `main` branch, so the workflow now runs on pushes to `main`.